### PR TITLE
compare deserialized strings, not strings

### DIFF
--- a/t/librarian/report.t
+++ b/t/librarian/report.t
@@ -9,6 +9,7 @@ use warnings;
 
 use Test::More;
 
+use JSON 2 ();
 use Test::Exception;
 use File::Temp ();
 use File::Path ();
@@ -53,6 +54,11 @@ for ( $new_fact, $new_fact->facts, $report, $report->facts ) {
   $_->{metadata}{core}{update_time} = $update_time;
 }
 
-is( $new_fact->content_as_bytes, $report->content_as_bytes, "fact content matches" );
+my $JSON = JSON->new;
+is_deeply(
+  $JSON->decode( $new_fact->content_as_bytes ),
+  $JSON->decode( $report->content_as_bytes   ),
+  "fact content matches",
+);
 
 is( $new_fact->resource, $report->resource, "dist name was indexed as expected" );


### PR DESCRIPTION
The $fact->as_content_bytes here are JSON built on demand.  The
JSON isn't built in a canonical order.  Rather than force that,
which would slow down reports (even if only a tiny bit), we'll
just deserialize the bytes into a structure that we can compare
with cmp_deeply!
